### PR TITLE
Update publish workflow to Trusted Providers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,10 @@
-name: Publish to PyPi
+name: Publish to PyPI
 on:
   release:
     types: [published]
 jobs:
   pypi-publish:
-    name: upload release to PyPi
+    name: upload release to PyPI
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,24 +1,29 @@
-name: Publish to PyPI
-
+name: Publish to PyPi
 on:
   release:
     types: [published]
-
 jobs:
-  publish:
+  pypi-publish:
+    name: upload release to PyPi
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/vllm-judge
+    permissions:
+      id-token: write
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.8'
-    - name: Install dependencies
-      run: |
-        pip install build twine
-    - name: Build package
-      run: python -m build
-    - name: Publish to PyPI
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-      run: twine upload dist/*
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          pip install build
+      - name: Build package
+        run: |
+          python3 -m build
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This PR updates `.github/workflows/publish.yml` to use PyPI's Trusted Publisher.

Issue: #2 