### PR TITLE
chore: Add Security Scan

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -33,7 +33,7 @@ jobs:
           fi
 
       - name: Run Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@77137e9dc3ab1b329b7c8a38c2eb7475850a14e8
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -43,7 +43,7 @@ jobs:
           exit-code: '0'
           
       - name: Check for critical and high vulnerabilities
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@77137e9dc3ab1b329b7c8a38c2eb7475850a14e8
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -92,7 +92,7 @@ jobs:
           pip install bandit[sarif]
 
       - name: Run Bandit Security Scan
-        uses: PyCQA/bandit-action@v1
+        uses: PyCQA/bandit-action@67a458d90fa11fb1463e91e7f4c8f068b5863c7f
         with:
           targets: "."
           exclude: "tests"

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: "pip"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -98,6 +98,14 @@ jobs:
           targets: "."
           exclude: "tests"
 
+      - name: Upload SARIF results to GitHub Security tab
+        if: github.ref == 'refs/heads/main'
+        uses: github/codeql-action/upload-sarif@86b04fb0e47484f7282357688f21d5d0e32175fe
+        with:
+          sarif_file: results.sarif
+          category: bandit-security-scan
+        continue-on-error: true
+
       - name: Upload SARIF as artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary by Sourcery

Add a GitHub Actions workflow to perform automated Trivy and Bandit security scans on code pushes and pull requests to the main branch, including SARIF reporting and artifact uploads.

CI:
- Create security-scan.yaml workflow triggered on pushes, pull requests, and manual dispatch
- Add Trivy job to scan the filesystem for vulnerabilities, output SARIF results, enforce failure on critical/high issues, and upload findings to the Security tab
- Add Bandit job to run a Python-focused security scan, generate SARIF output, and upload results as artifacts